### PR TITLE
Updated version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "com.alex.diafaneia"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 20
-        versionName "20.0"
+        versionCode 21
+        versionName "21.0"
         multiDexEnabled true
     }
     buildTypes {

--- a/app/src/main/java/com/example/alex/diafaneia/MainActivity.java
+++ b/app/src/main/java/com/example/alex/diafaneia/MainActivity.java
@@ -288,7 +288,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
             public void onClick(View v) {
                 c8.setImageResource(R.drawable.cancel_button_minimal);
                 EditText text = (EditText) findViewById(R.id.etxt_fromdate);
-                text.setText("01/01/2014");
+                text.setText("01/01/2016");
                 fromDate = null;
 
 //                InputMethodManager imm = (InputMethodManager) RL1.getContext()
@@ -411,7 +411,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                 free_Text_str = null;
                 c8.setImageResource(R.drawable.cancel_button_minimal);
                 EditText text = (EditText) findViewById(R.id.etxt_fromdate);
-                text.setText("01/01/2014");
+                text.setText("01/01/2016");
                 fromDate = null;
                 c9.setImageResource(R.drawable.cancel_button_minimal);
                 EditText text2 = (EditText) findViewById(R.id.etxt_todate);

--- a/app/src/main/res/layout-large/activity_main.xml
+++ b/app/src/main/res/layout-large/activity_main.xml
@@ -583,7 +583,7 @@
                         android:layout_height="wrap_content"
                         android:layout_weight=".5"
                         android:hint="@string/from_date"
-                        android:text="01/01/2014"
+                        android:text="01/01/2016"
                         android:layout_alignEnd="@+id/textView10"
                         android:layout_marginTop="23dp"
                         android:fontFamily="sans-serif-light"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -136,7 +136,7 @@
                         android:textColor="#FF36BAF6"
                         android:paddingLeft="5dp"
                         android:paddingStart="5dp"
-                        android:layout_marginLeft="25dp"
+                        android:layout_marginLeft="35dp"
                         android:textSize="24sp"
                         android:fontFamily="sans-serif-light"/>
 
@@ -724,7 +724,6 @@
                         android:textSize="24sp"
                         android:paddingLeft="2dp"
                         android:paddingStart="2dp"
-                        android:layout_marginLeft="25dp"
                         android:layout_alignParentTop="true"
                         android:layout_alignParentLeft="true"
                         android:layout_alignParentStart="true"
@@ -752,7 +751,7 @@
                         android:focusableInTouchMode="true"
                         android:layout_height="wrap_content"
                         android:hint="@string/from_date"
-                        android:text="01/01/2014"
+                        android:text="01/01/2016"
                         android:layout_alignEnd="@+id/textView10"
                         android:layout_alignTop="@+id/textView11"
                         android:layout_marginTop="18dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">Διαφάνεια</string>
-    <string name="from_date">01/01/2014</string>
+    <string name="from_date">01/01/2016</string>
     <string name="to_date">20/4/2016</string>
     <string name="info">Το τηλεφωνικό κέντρο της Βουλής των Ελλήνων είναι:</string>
     <string name="telephone">Τηλ: <a href="+302103707000">+30 210 370 7000</a> </string>


### PR DESCRIPTION
New version for Google Play

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release-prep changes: version bump plus small UI/default-value tweaks with no changes to core logic or data handling.
> 
> **Overview**
> Bumps the Android app version for a Google Play release (`versionCode` 21 / `versionName` 21.0).
> 
> Updates the default "from" date used in the search UI from `01/01/2014` to `01/01/2016` across `strings.xml`, both `activity_main.xml` layouts, and the reset/clear handlers in `MainActivity`. Also includes minor layout spacing tweaks (e.g., left margin adjustments/removal for some labels).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fc820c8d764d9d30ac830e2f7925454264d455c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->